### PR TITLE
Fix calculate fire date for zero day of week.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 package-lock.json
 delete_me.*
+.DS_Store

--- a/lib/fire-date.js
+++ b/lib/fire-date.js
@@ -72,13 +72,13 @@ const self = module.exports = function(expression, { firstDayOfWeek = 0, fireDat
     let pureDaysOfMonth = daysOfMonth.filter(dayOfMonth => dayOfMonth <= lastDayOfMonth)
     if(!pureDaysOfMonth.length) throw new Error(`[${daysOfMonth}]: Invalid days of month.`)
     if(thisYear !== fireYear || thisMonth !== fireMonth) fireDate.setDate(1)
-    let fireDayOfMonth = fireDate.getDate()
-    let nextDayOfMonth = pureDaysOfMonth.find(dayOfMonth => dayOfMonth > fireDayOfMonth)
-    let currentDayOfMonth = pureDaysOfMonth.find(dayOfMonth => dayOfMonth === fireDayOfMonth)
+    let fireDateOfMonth = fireDate.getDate()
+    let nextDayOfMonth = pureDaysOfMonth.find(dayOfMonth => dayOfMonth > fireDateOfMonth)
+    let currentDayOfMonth = pureDaysOfMonth.find(dayOfMonth => dayOfMonth === fireDateOfMonth)
     if(!currentDayOfMonth) {
         if(nextDayOfMonth) {
-            let diffDayOfMonth = nextDayOfMonth - fireDayOfMonth
-            fireDate.setDate(fireDayOfMonth + diffDayOfMonth)
+            let diffDayOfMonth = nextDayOfMonth - fireDateOfMonth
+            fireDate.setDate(fireDateOfMonth + diffDayOfMonth)
         } else {
             fireDate.setMonth(fireMonth) // Already incremented by 1.
             fireDate.setDate(pureDaysOfMonth[0])
@@ -89,7 +89,7 @@ const self = module.exports = function(expression, { firstDayOfWeek = 0, fireDat
     // #############
 
     // Day Of Week Process
-    fireDayOfMonth = fireDate.getDate()
+    fireDateOfMonth = fireDate.getDate()
     let fireDayOfWeek = dayOfWeek(fireDate, { firstDayOfWeek })
     let daysOfWeekByFirstDayOfWeek = daysOfWeek.map(dayOfWeek => ~((firstDayOfWeek - dayOfWeek - 7) % 7) + 1).sort((a, b) => a - b)
     let nextDayOfWeek = daysOfWeekByFirstDayOfWeek.find(dayOfWeek => dayOfWeek > fireDayOfWeek)
@@ -97,10 +97,10 @@ const self = module.exports = function(expression, { firstDayOfWeek = 0, fireDat
     if(!currentDayOfWeek && currentDayOfWeek !== 0) {
         if(nextDayOfWeek) {
             let diffDayOfWeek = nextDayOfWeek - fireDayOfWeek
-            fireDate.setDate(fireDayOfMonth + diffDayOfWeek)
+            fireDate.setDate(fireDateOfMonth + diffDayOfWeek)
         } else {
-            let diffDayOfWeek = fireDayOfWeek - daysOfWeekByFirstDayOfWeek[0]
-            fireDate.setDate(fireDayOfMonth - diffDayOfWeek)
+            let diffDayOfWeek = Math.abs(fireDayOfWeek - (daysOfWeekByFirstDayOfWeek[0] === 0 ? 7 : daysOfWeekByFirstDayOfWeek[0]))
+            fireDate.setDate(fireDateOfMonth + diffDayOfWeek)
             fireDate.setHours(0, 0, 0, 0)
             return self(expression, { firstDayOfWeek, fireDate })
         }
@@ -110,7 +110,7 @@ const self = module.exports = function(expression, { firstDayOfWeek = 0, fireDat
     // Hour Process
     fireYear = fireDate.getFullYear()
     fireMonth = fireDate.getMonth() + 1
-    if(thisYear !== fireYear || thisMonth !== fireMonth || fireDayOfMonth > thisDayOfMonth) fireDate.setHours(0, 0, 0, 0)
+    if(thisYear !== fireYear || thisMonth !== fireMonth || fireDateOfMonth > thisDayOfMonth) fireDate.setHours(0, 0, 0, 0)
     let fireHours = fireDate.getHours()
     let nextHour = hours.find(hour => hour > fireHours)
     let currentHour = hours.find(hour => hour === fireHours)

--- a/test/lib_fire-date.test.js
+++ b/test/lib_fire-date.test.js
@@ -23,4 +23,8 @@ describe("fireDate", function() {
     it(`fireDate("25 2-5 29,31 9 *", { firstDayOfWeek: 1, fireDate: new Date("2022-08-20 22:55") }) --> Returns the date of the invocation for Turkey first day of week and for 20.08.2022 22:55.`, function() {
         assert.deepEqual(fireDate("25 2-5 29,31 9 *", { firstDayOfWeek: 1, fireDate: new Date("2022-08-20 22:55") }), new Date("2022-09-29 02:25:00"))
     })
+
+    it(`fireDate("00 21 * * 0", { firstDayOfWeek: 0, fireDate: new Date("2024-05-05 22:40") }) --> Returns the date of the invocation for first day is sunday of week and for 05.05.2024 22:40.`, function() {
+        assert.deepEqual(fireDate("00 21 * * 0", { firstDayOfWeek: 0, fireDate: new Date("2024-05-05 22:40") }), new Date("2024-05-12 21:00:00"))
+    })
 })


### PR DESCRIPTION
[TR]
Haftanın ilk günü için tetiklenme zamanı hatalı hesaplanıyordu. Bunun sebebi haftanın günleri gerçekte indeks değeri 1 ile başlarken javascript indeks değeri olarak 0 ile başlar. Hesaplama sırasında gün farkı alınırken 0 yerine 7 yazılarak gerçek fark değeri elde edilmiştir.

[EN]
The fire time for the first day of the week was calculated incorrectly. This is because the days of the week actually index value starts with 1, while the javascript index value starts with 0. While calculating the day difference, the actual difference value was obtained by writing 7 instead of 0.